### PR TITLE
fix: Pin attrs version to 23.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     # bentoml[io] includes pydantic, PIL, filetype, pandas and numpy
     # bentoml[grpc,grpc-reflection] include grpcio, grpcio-reflection
     "bentoml[io]>=1.1.2",
-    "attrs>=23.1.0",
+    "attrs==23.1.0",
     "cattrs>=23.1.0",
     # diffusers
     "diffusers[torch]>=0.19.3",


### PR DESCRIPTION
The `attrs` package was recently updated to version 23.2.0 [here](https://github.com/python-attrs/attrs/releases/tag/23.2.0).

Version 23.2.0 is a breaking change since it adds a new argument called `__attrs_pre_init__` to the `_make_init()` function. 


This was the traceback from running `attrs==23.2.0`.
```bash
(3.8) [root@ip-172-31-28-41 ~]# onediffusion -h
Traceback (most recent call last):
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/utils/lazy.py", line 120, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "/root/miniconda3/envs/3.8/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/models/stable_diffusion/configuration_stable_diffusion.py", line 23, in <module>
    class StableDiffusionConfig(onediffusion.SDConfig):
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/_configuration.py", line 592, in __init_subclass__
    _make_init(
TypeError: _make_init() missing 1 required positional argument: 'cls_on_setattr'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/miniconda3/envs/3.8/bin/onediffusion", line 5, in <module>
    from onediffusion.cli import cli
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/cli.py", line 745, in <module>
    _cached_http = {key: start_model_command(key, _context_settings=_CONTEXT_SETTINGS) for key in onediffusion.CONFIG_MAPPING}
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/cli.py", line 745, in <dictcomp>
    _cached_http = {key: start_model_command(key, _context_settings=_CONTEXT_SETTINGS) for key in onediffusion.CONFIG_MAPPING}
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/cli.py", line 522, in start_model_command
    sd_config = onediffusion.AutoConfig.for_model(model_name)
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/models/auto/configuration_auto.py", line 113, in for_model
    return CONFIG_MAPPING[model_name].model_construct_env(**attrs)
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/models/auto/configuration_auto.py", line 64, in __getitem__
    if hasattr(self._modules[module_name], value):
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/bentoml/_internal/utils/lazy_loader.py", line 70, in __getattr__
    return getattr(self._module, item)
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/utils/lazy.py", line 110, in __getattr__
    module = self._get_module(self._class_to_module.__getitem__(name))
  File "/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/utils/lazy.py", line 122, in _get_module
    raise RuntimeError(
RuntimeError: Failed to import onediffusion.models.stable_diffusion.configuration_stable_diffusion because of the following error (look up to see its traceback):
_make_init() missing 1 required positional argument: 'cls_on_setattr'
```




Downgrading to `attrs==23.1.0` fixed the problem:
```bash
(3.8) [root@ip-172-31-28-41 ~]# pip install attrs==23.1.0
Collecting attrs==23.1.0
  Downloading attrs-23.1.0-py3-none-any.whl (61 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.2/61.2 kB 3.9 MB/s eta 0:00:00
Installing collected packages: attrs
  Attempting uninstall: attrs
    Found existing installation: attrs 23.2.0
    Uninstalling attrs-23.2.0:
      Successfully uninstalled attrs-23.2.0
Successfully installed attrs-23.1.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
(3.8) [root@ip-172-31-28-41 ~]# onediffusion -h
/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/_configuration.py:832: RuntimeWarning: The empty option group "StableDiffusionConfig options" was found (line 832) for "model_start". The group will not be added.
  return cog.optgroup.group(f"{cls.__name__} options")(f)
/root/miniconda3/envs/3.8/lib/python3.8/site-packages/onediffusion/_configuration.py:832: RuntimeWarning: The empty option group "StableDiffusionXLConfig options" was found (line 832) for "model_start". The group will not be added.
  return cog.optgroup.group(f"{cls.__name__} options")(f)
Usage: onediffusion [OPTIONS] COMMAND [ARGS]...

       ██████╗ ███╗   ██╗███████╗██████╗ ██╗███████╗███████╗██╗   ██╗███████╗██╗ ██████╗ ███╗   ██╗
      ██╔═══██╗████╗  ██║██╔════╝██╔══██╗██║██╔════╝██╔════╝██║   ██║██╔════╝██║██╔═══██╗████╗  ██║
      ██║   ██║██╔██╗ ██║█████╗  ██║  ██║██║█████╗  █████╗  ██║   ██║███████╗██║██║   ██║██╔██╗ ██║
      ██║   ██║██║╚██╗██║██╔══╝  ██║  ██║██║██╔══╝  ██╔══╝  ██║   ██║╚════██║██║██║   ██║██║╚██╗██║
      ╚██████╔╝██║ ╚████║███████╗██████╔╝██║██║     ██║     ╚██████╔╝███████║██║╚██████╔╝██║ ╚████║
       ╚═════╝ ╚═╝  ╚═══╝╚══════╝╚═════╝ ╚═╝╚═╝     ╚═╝      ╚═════╝ ╚══════╝╚═╝ ╚═════╝ ╚═╝  ╚═══╝

          An open platform for operating diffusion models in production.
          Fine-tune, serve, deploy, and monitor any diffusion models with ease.


Options:
  -v, --version  Show the version and exit.
  -h, --help     Show this message and exit.

Commands:
  build     Package a given model into a Bento.
  download  Setup diffusion models interactively.
  start     Start any diffusion models as a REST server.
```