### PR TITLE
docs: fix typo in HF_TOKEN environment variable name

### DIFF
--- a/sd3-medium/README.md
+++ b/sd3-medium/README.md
@@ -20,7 +20,7 @@ cd BentoDiffusion/sd3-medium
 # Recommend Python 3.11
 pip install -r requirements.txt
 
-export HF_TOEKN=<your-api-key>
+export HF_TOKEN=<your-api-key>
 ```
 
 ## Run the BentoML Service


### PR DESCRIPTION
# Fix typo in Hugging Face token environment variable

## Description
Fixed a typo in the README.md documentation where the Hugging Face token environment variable was incorrectly spelled as `HF_TOEKN` instead of `HF_TOKEN`.

## Changes Made
- Updated the environment variable name in [sd3-medium/README.md] from `HF_TOEKN` to `HF_TOKEN`

## Impact
This change ensures users can properly set up their environment variables by following the correct variable name in the documentation.

## Testing
No functional changes - documentation update only.